### PR TITLE
feat: ONENIL-4 - Add scorers to latest result

### DIFF
--- a/src/app/components/LatestResultBlock.tsx
+++ b/src/app/components/LatestResultBlock.tsx
@@ -33,6 +33,17 @@ export default async function LatestResultBlock() {
     typeof homeScore === 'number' && typeof awayScore === 'number';
   const scoreLabel = hasScore ? `${homeScore} - ${awayScore}` : 'TBD';
 
+  // Parse scorers - handle both string and array formats from Contentful
+  const parseScorers = (scorers: string | string[] | undefined): string[] => {
+    if (!scorers) return [];
+    if (Array.isArray(scorers)) return scorers;
+    if (typeof scorers === 'string') return scorers.split(',').map((s) => s.trim());
+    return [];
+  };
+
+  const homeScorersList = parseScorers(homeScorers);
+  const awayScorersList = parseScorers(awayScorers);
+
   return (
     <section className="py-16 md:py-20 bg-gradient-to-br from-red-600 via-red-700 to-red-800 text-white relative overflow-hidden">
       {/* Decorative elements */}
@@ -93,15 +104,15 @@ export default async function LatestResultBlock() {
           </div>
 
           {/* Scorers */}
-          {(homeScorers || awayScorers) && (
+          {(homeScorersList.length > 0 || awayScorersList.length > 0) && (
             <div className="flex justify-between mt-6 pt-6 border-t border-white/20">
               {/* Home Scorers */}
               <div className="flex-1 text-right pr-4 md:pr-8">
-                {homeScorers && (
+                {homeScorersList.length > 0 && (
                   <div className="text-sm md:text-base text-white/80 space-y-1">
-                    {homeScorers.split(',').map((scorer, i) => (
+                    {homeScorersList.map((scorer, i) => (
                       <p key={i} className="flex items-center justify-end gap-2">
-                        <span>{scorer.trim()}</span>
+                        <span>{scorer}</span>
                         <span className="text-lg">⚽</span>
                       </p>
                     ))}
@@ -111,12 +122,12 @@ export default async function LatestResultBlock() {
 
               {/* Away Scorers */}
               <div className="flex-1 text-left pl-4 md:pl-8">
-                {awayScorers && (
+                {awayScorersList.length > 0 && (
                   <div className="text-sm md:text-base text-white/80 space-y-1">
-                    {awayScorers.split(',').map((scorer, i) => (
+                    {awayScorersList.map((scorer, i) => (
                       <p key={i} className="flex items-center gap-2">
                         <span className="text-lg">⚽</span>
-                        <span>{scorer.trim()}</span>
+                        <span>{scorer}</span>
                       </p>
                     ))}
                   </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,8 +85,8 @@ export type MatchEventFields = {
   ticketLink?: string;
   homeScore?: number;
   awayScore?: number;
-  homeScorers?: string;
-  awayScorers?: string;
+  homeScorers?: string | string[];
+  awayScorers?: string | string[];
   teamHome: Entry<TeamSkeleton>;
   teamAway: Entry<TeamSkeleton>;
   heroBanner: Asset;


### PR DESCRIPTION
## Summary
- Add `homeScorers` and `awayScorers` fields to `MatchEventFields` type
- Display goal scorers below the score in the Latest Result block
- Scorers shown with ⚽ emoji, aligned to their respective team side
- Uses comma-separated format from Contentful (e.g., "Soler 23', Isaac 45', Jesus Navas 78'")
- Section only displays when scorer data is available

## Contentful Setup Required
Add two new fields to the `matchEvent` content type:
- `homeScorers` (Short text) - comma-separated list of home team scorers
- `awayScorers` (Short text) - comma-separated list of away team scorers

## Test plan
- [ ] Add scorer data to a match in Contentful
- [ ] Verify scorers display correctly below the score
- [ ] Test with only home scorers
- [ ] Test with only away scorers
- [ ] Test with no scorers (section should be hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)