### PR TITLE
fix: ONENIL-5 - Center hero images for better content visibility

### DIFF
--- a/src/app/components/HeroComponent.tsx
+++ b/src/app/components/HeroComponent.tsx
@@ -48,7 +48,7 @@ export default function HeroCarousel({ articles }: HeroCarouselProps) {
             fill
             sizes="100vw"
             priority={index === 0}
-            className="object-cover object-top"
+            className="object-cover object-center"
           />
 
           {/* Multi-layer overlay for depth */}


### PR DESCRIPTION
## Summary
- Changed hero image positioning from `object-top` to `object-center`
- Ensures vital content (players, action, main subjects) stays visible when images scale on different screen sizes

## Problem
Hero images were anchored to the top, causing the center/bottom content to be cut off on smaller viewports.

## Solution
Use `object-center` to keep the focal point of images visible across all screen sizes.

## Test plan
- [ ] View homepage hero on desktop - center of image should be visible
- [ ] View homepage hero on mobile - center of image should still be visible
- [ ] Test with different hero images to verify focal points are maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)