### PR TITLE
Fix NextMatch mobile layout and countdown timer

### DIFF
--- a/src/app/components/CountdownComponent.tsx
+++ b/src/app/components/CountdownComponent.tsx
@@ -49,26 +49,26 @@ export default function Countdown({ targetDate }: { targetDate: Date }) {
   ];
 
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex flex-col items-center gap-3 sm:gap-4 w-full px-2 sm:px-4">
       {/* Kick-off label */}
-      <p className="text-white/60 text-sm font-medium uppercase tracking-widest">
+      <p className="text-white/60 text-xs sm:text-sm font-medium uppercase tracking-widest">
         Kick-off in
       </p>
 
       {/* Countdown boxes */}
-      <div className="flex items-center gap-2 md:gap-4">
+      <div className="flex items-center gap-1 sm:gap-2 md:gap-4 justify-center w-full">
         {timeUnits.map((unit, index) => (
-          <div key={unit.label} className="flex items-center gap-2 md:gap-4">
+          <div key={unit.label} className="flex items-center gap-1 sm:gap-2 md:gap-4">
             {/* Time unit box */}
             <div className="flex flex-col items-center">
               <div className="relative">
                 {/* Background glow */}
-                <div className="absolute inset-0 bg-red-500/20 rounded-xl blur-xl" />
+                <div className="absolute inset-0 bg-red-500/20 rounded-lg sm:rounded-xl blur-lg sm:blur-xl" />
 
                 {/* Main box */}
-                <div className="relative bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl px-3 py-3 md:px-5 md:py-4 min-w-[60px] md:min-w-[80px]">
+                <div className="relative bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg sm:rounded-xl px-2 py-2 sm:px-3 sm:py-3 md:px-5 md:py-4 min-w-[48px] sm:min-w-[60px] md:min-w-[80px]">
                   <span
-                    className={`block text-2xl md:text-4xl font-bold text-white tabular-nums text-center ${
+                    className={`block text-xl sm:text-2xl md:text-4xl font-bold text-white tabular-nums text-center ${
                       mounted ? 'transition-all duration-300' : ''
                     }`}
                   >
@@ -78,16 +78,16 @@ export default function Countdown({ targetDate }: { targetDate: Date }) {
               </div>
 
               {/* Label */}
-              <span className="mt-2 text-xs md:text-sm text-white/50 font-medium uppercase tracking-wider">
+              <span className="mt-1.5 sm:mt-2 text-[10px] sm:text-xs md:text-sm text-white/50 font-medium uppercase tracking-wider">
                 {unit.label}
               </span>
             </div>
 
             {/* Separator (not after last item) */}
             {index < timeUnits.length - 1 && (
-              <div className="flex flex-col gap-1.5 pb-6">
-                <span className="w-1.5 h-1.5 md:w-2 md:h-2 rounded-full bg-white/40" />
-                <span className="w-1.5 h-1.5 md:w-2 md:h-2 rounded-full bg-white/40" />
+              <div className="flex flex-col gap-1 sm:gap-1.5 pb-4 sm:pb-6">
+                <span className="w-1 h-1 sm:w-1.5 sm:h-1.5 md:w-2 md:h-2 rounded-full bg-white/40" />
+                <span className="w-1 h-1 sm:w-1.5 sm:h-1.5 md:w-2 md:h-2 rounded-full bg-white/40" />
               </div>
             )}
           </div>

--- a/src/app/components/NextMatchBlock.tsx
+++ b/src/app/components/NextMatchBlock.tsx
@@ -47,10 +47,10 @@ export default async function NextMatchBlock() {
         </h2>
 
         {/* Teams Display */}
-        <div className="glass-dark rounded-3xl p-8 md:p-12 inline-block mx-auto max-w-2xl">
-          <div className="flex items-center justify-center gap-6 md:gap-12">
+        <div className="glass-dark rounded-3xl p-4 sm:p-6 md:p-12 inline-block mx-auto max-w-2xl w-full">
+          <div className="flex items-center justify-center gap-3 sm:gap-6 md:gap-12">
             {/* Home Team */}
-            <div className="flex flex-col items-center group">
+            <div className="flex flex-col items-center group flex-1 min-w-0">
               {matchViewModel?.teamHome.logoUrl && (
                 <div className="relative">
                   <Image
@@ -58,22 +58,22 @@ export default async function NextMatchBlock() {
                     alt={matchViewModel?.teamHome.name}
                     width={64}
                     height={64}
-                    className="h-16 w-16 md:h-20 md:w-20 object-contain transition-transform duration-300 group-hover:scale-110"
+                    className="h-12 w-12 sm:h-16 sm:w-16 md:h-20 md:w-20 object-contain transition-transform duration-300 group-hover:scale-110"
                   />
                 </div>
               )}
-              <span className="mt-3 font-semibold text-sm md:text-base">
+              <span className="mt-2 sm:mt-3 font-semibold text-xs sm:text-sm md:text-base text-center truncate w-full px-1">
                 {matchViewModel?.teamHome.name}
               </span>
             </div>
 
             {/* VS */}
-            <div className="text-2xl md:text-3xl font-bold text-white/60 px-2">
+            <div className="text-xl sm:text-2xl md:text-3xl font-bold text-white/60 px-1 sm:px-2 flex-shrink-0">
               vs
             </div>
 
             {/* Away Team */}
-            <div className="flex flex-col items-center group">
+            <div className="flex flex-col items-center group flex-1 min-w-0">
               {matchViewModel?.teamAway.logoUrl && (
                 <div className="relative">
                   <Image
@@ -81,11 +81,11 @@ export default async function NextMatchBlock() {
                     alt={matchViewModel?.teamAway.name}
                     width={64}
                     height={64}
-                    className="h-16 w-16 md:h-20 md:w-20 object-contain transition-transform duration-300 group-hover:scale-110"
+                    className="h-12 w-12 sm:h-16 sm:w-16 md:h-20 md:w-20 object-contain transition-transform duration-300 group-hover:scale-110"
                   />
                 </div>
               )}
-              <span className="mt-3 font-semibold text-sm md:text-base">
+              <span className="mt-2 sm:mt-3 font-semibold text-xs sm:text-sm md:text-base text-center truncate w-full px-1">
                 {matchViewModel?.teamAway.name}
               </span>
             </div>


### PR DESCRIPTION
- Reduce NextMatchBlock padding on mobile (p-4 vs p-8)
- Scale team logos appropriately (48px mobile, 64px tablet, 80px desktop)
- Optimize spacing with progressive gaps (gap-3 → gap-6 → gap-12)
- Add text truncation to prevent team name overflow
- Reduce countdown box width on mobile (48px vs 60px)
- Tighten countdown gaps and reduce font size for mobile
- Make all countdown elements fully visible on small screens (320px+)
- Add responsive breakpoints for smooth scaling across devices

Fixes countdown seconds being cut off on mobile devices. Total mobile width reduced from ~360px to ~296px.