### PR TITLE
ONENIL-9: Add spacing between Hero and Next Match sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,9 @@ export default async function HomePage() {
       {/* Hero Section */}
       <HeroCarousel articles={articlesHero} />
 
+      {/* Spacer between Hero and Next Match */}
+      <div className="h-8 md:h-12 bg-gradient-to-b from-black/80 to-transparent" />
+
       {/* Upcoming Match */}
       <NextMatchBlock />
 


### PR DESCRIPTION
## Summary
- Added a gradient spacer element between the Hero carousel and Next Match block
- Creates visual breathing room with 32px (mobile) / 48px (desktop) spacing
- Gradient transitions smoothly from dark overlay to transparent

## Test plan
- [ ] Verify spacing appears between Hero and Next Match on homepage
- [ ] Check responsive behavior on mobile and desktop
- [ ] Ensure gradient blends naturally with both sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)