### PR TITLE
fix(results): adjust match visibility and hero fallback styling

### DIFF
--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -104,22 +104,16 @@ export default async function ResultsPage() {
       {/* Latest Result Hero Banner */}
       {latestResult && (
         <section
-          className="relative text-white pt-24 md:pt-28 pb-12 md:pb-16 bg-black overflow-hidden"
+          className="relative text-white pt-28 md:pt-36 pb-16 md:pb-24 bg-cover bg-top bg-no-repeat overflow-hidden bg-black"
+          style={
+            heroBannerUrl
+              ? { backgroundImage: `url(${heroBannerUrl})` }
+              : undefined
+          }
         >
-          {/* Background image - auto height to show more of image */}
-          {heroBannerUrl && (
-            <div
-              className="absolute inset-0 bg-contain bg-top bg-no-repeat"
-              style={{
-                backgroundImage: `url(${heroBannerUrl})`,
-                backgroundPosition: 'center top',
-                backgroundSize: 'auto 100%',
-              }}
-            />
-          )}
           {/* Gradient overlays */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black via-black/70 to-black/40" />
-          {/* Side gradients to fade image edges into black */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-black/30" />
+          {/* Stronger side gradients for images that don't fill the width */}
           <div className="absolute inset-0 bg-gradient-to-r from-black via-transparent to-black" />
 
           {/* Fallback gradient if no banner - softer red tones */}


### PR DESCRIPTION
## Summary
- Only display matches that started at least 4 hours ago (to allow for match completion)
- Soften the red fallback background for matches without hero images
- Apply consistent lighter red to "No results" fallback section

## Changes
**Match filtering logic:**
- Changed from `now` to `now - 4 hours` for the date filter
- Matches within 0-4 hours after kickoff are now excluded

**Hero fallback styling:**
- Changed gradient from `red-600/700/800` to `red-400/500/600` (lighter tones)
- Applied same lighter gradient to "No results" fallback section

## Test plan
- [ ] Verify matches within 4 hours of kickoff don't appear on Results page
- [ ] Verify matches older than 4 hours appear correctly
- [ ] Check fallback red is visibly lighter when no hero image is present
- [ ] Confirm matches with hero images display correctly (no regression)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)