### PR TITLE
feat(match): use stadium photo for upcoming matches

### DIFF
--- a/src/app/matches/[slug]/page.tsx
+++ b/src/app/matches/[slug]/page.tsx
@@ -14,12 +14,18 @@ export default async function MatchPage(props: {
 
   const matchStatus = getMatchStatus(matchViewModel.targetDate);
 
+  // Use stadium photo for upcoming matches, hero banner for completed/live matches
+  const heroImageUrl =
+    matchStatus === 'pre-match'
+      ? matchViewModel.homeStadiumPhotoUrl || matchViewModel.heroBannerUrl
+      : matchViewModel.heroBannerUrl;
+
   return (
     <div className="min-h-screen bg-slate-50">
       {/* Hero Section */}
       <section
-        className="relative w-full bg-cover bg-center bg-no-repeat text-white pt-24 md:pt-28 pb-12 md:pb-16 overflow-hidden"
-        style={{ backgroundImage: `url('${matchViewModel.heroBannerUrl}')` }}
+        className="relative w-full bg-cover bg-center bg-no-repeat text-white pt-24 md:pt-28 pb-12 md:pb-16 overflow-hidden bg-slate-900"
+        style={heroImageUrl ? { backgroundImage: `url('${heroImageUrl}')` } : undefined}
       >
         {/* Overlay */}
         <div className="absolute inset-0 bg-gradient-to-t from-black via-black/70 to-black/50" />

--- a/src/lib/serverUtils.tsx
+++ b/src/lib/serverUtils.tsx
@@ -36,9 +36,11 @@ export async function getMatchViewModel(
   const awayTeam = teamAway as Entry<TeamSkeleton>;
   let homeLogoUrl: string | undefined = undefined;
   let awayLogoUrl: string | undefined = undefined;
+  let homeStadiumPhotoUrl: string | undefined = undefined;
 
   const homeTeamLogo = homeTeam.fields.logo as unknown as Asset;
   const awayTeamLogo = awayTeam.fields.logo as unknown as Asset;
+  const homeTeamStadiumPhoto = homeTeam.fields.stadiumPhoto as unknown as Asset;
   const homeTeamName = homeTeam.fields.name! as unknown as string;
   const homeTeamShortName = homeTeam.fields.name! as unknown as string;
   const awayTeamName = awayTeam.fields.shortName! as unknown as string;
@@ -51,6 +53,10 @@ export async function getMatchViewModel(
   if (awayTeamLogo.sys?.id) {
     awayLogoUrl = resolveAsset(awayTeamLogo.sys?.id, assets);
   }
+
+  if (homeTeamStadiumPhoto?.sys?.id) {
+    homeStadiumPhotoUrl = resolveAsset(homeTeamStadiumPhoto.sys.id, assets);
+  }
   const date = new Date(match.fields.date);
   const formattedDate = format(date, 'dd MMM yyyy');
   const formattedTime = date.toLocaleTimeString('en-GB', {
@@ -58,6 +64,11 @@ export async function getMatchViewModel(
     minute: '2-digit',
     hour12: false,
   });
+
+  const heroBannerAsset = heroBanner as Asset;
+  const heroBannerUrl = heroBannerAsset?.fields?.file?.url
+    ? `https:${heroBannerAsset.fields.file.url}`
+    : undefined;
 
   return {
     title: match.fields.title,
@@ -68,7 +79,8 @@ export async function getMatchViewModel(
     kickoffTime: formattedTime,
     competition: match.fields.competition,
     ticketLink: match.fields.ticketLink,
-    heroBannerUrl: `https:${(heroBanner as Asset)?.fields?.file?.url}`,
+    heroBannerUrl,
+    homeStadiumPhotoUrl,
     teamHome: {
       name: homeTeamName,
       shortName: homeTeamShortName,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,7 @@ export type TeamFields = {
   shortName?: string;
   slug: string;
   logo: Asset;
+  stadiumPhoto?: Asset;
   foundationYear?: number;
   city?: string;
   stadium?: string;

--- a/src/lib/viewModels.tsx
+++ b/src/lib/viewModels.tsx
@@ -7,7 +7,8 @@ export type MatchViewModel = {
   kickoffTime: string;
   competition: string;
   ticketLink?: string;
-  heroBannerUrl: string;
+  heroBannerUrl?: string;
+  homeStadiumPhotoUrl?: string;
   teamHome: {
     name: string;
     shortName?: string;


### PR DESCRIPTION
## Summary
Display the home team's stadium photo as hero image for upcoming matches, and use the match hero image only for completed games.

## Changes
- **src/lib/types.ts**: Added `stadiumPhoto?: Asset` to `TeamFields`
- **src/lib/viewModels.tsx**: Added `homeStadiumPhotoUrl?: string` to `MatchViewModel`
- **src/lib/serverUtils.tsx**: Fetch and return home team's stadium photo URL
- **src/app/matches/[slug]/page.tsx**: Conditionally use stadium photo or hero banner based on match status

## Hero Image Logic
| Match Status | Hero Image |
|--------------|------------|
| Pre-match (upcoming) | Home team stadium photo |
| Live | Match hero banner |
| Post-match (completed) | Match hero banner |

Falls back to hero banner if stadium photo is not available.

## Test Plan
- [ ] Add `stadiumPhoto` field to Team content type in Contentful
- [ ] Upload a stadium photo for a team
- [ ] Visit an upcoming match page → should show stadium photo
- [ ] Visit a completed match page → should show hero banner
- [ ] Test fallback when stadium photo is missing

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)