### PR TITLE
feat: filter all season-scoped data by active season

### DIFF
--- a/src/app/components/LatestResultBlock.tsx
+++ b/src/app/components/LatestResultBlock.tsx
@@ -1,27 +1,16 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { contentfulClient } from '@/lib/contentful';
-import { MatchEventFields, MatchEventSkeleton } from '@/lib/types';
-import { getMatchViewModel } from '@/lib/serverUtils';
+import { MatchEventFields } from '@/lib/types';
+import { getLatestResult, getMatchViewModel } from '@/lib/serverUtils';
 
 export default async function LatestResultBlock() {
-  const query = {
-    content_type: 'matchEvent',
-    limit: 1,
-    include: 2,
-    order: ['-fields.date'],
-    'fields.date[lte]': new Date().toISOString(),
-  };
-  const res = await contentfulClient.getEntries<MatchEventSkeleton>(
-    query as any // eslint-disable-line @typescript-eslint/no-explicit-any
-  );
-  const match = res.items[0];
+  const { match } = await getLatestResult();
 
   if (!match) {
     return null;
   }
 
-  const matchViewModel = await getMatchViewModel(match.fields.slug);
+  const matchViewModel = await getMatchViewModel(match.fields.slug as unknown as string);
 
   if (!matchViewModel) {
     return null;

--- a/src/app/components/NextMatchBlock.tsx
+++ b/src/app/components/NextMatchBlock.tsx
@@ -1,22 +1,12 @@
-import { contentfulClient } from '@/lib/contentful';
 import Link from 'next/link';
-import { MatchEventFields, MatchEventSkeleton } from '@/lib/types';
-import { getMatchViewModel } from '@/lib/serverUtils';
+import { MatchEventFields } from '@/lib/types';
+import { getMatchViewModel, getNextMatch } from '@/lib/serverUtils';
 import Image from 'next/image';
 import Countdown from './CountdownComponent';
 
 export default async function NextMatchBlock() {
-  const query = {
-    content_type: 'matchEvent',
-    limit: 1,
-    include: 2,
-    order: ['fields.date'],
-    'fields.date[gte]': new Date().toISOString(),
-  };
-  const res = await contentfulClient.getEntries<MatchEventSkeleton>(
-    query as any // eslint-disable-line @typescript-eslint/no-explicit-any
-  );
-  const match = res.items[0];
+  const { match } = await getNextMatch();
+
   if (!match) {
     return (
       <div className="text-center text-gray-600 py-6">
@@ -26,7 +16,7 @@ export default async function NextMatchBlock() {
   }
 
   const { date, slug } = match.fields as MatchEventFields;
-  const matchViewModel = await getMatchViewModel(match.fields.slug);
+  const matchViewModel = await getMatchViewModel(match.fields.slug as unknown as string);
 
   return (
     <section

--- a/src/app/components/ShortLeagueTable.tsx
+++ b/src/app/components/ShortLeagueTable.tsx
@@ -1,10 +1,10 @@
 import { LeagueTableEntry } from '@/lib/types';
-import { getAllTeamLogos, getLastSeason } from '@/lib/serverUtils';
+import { getAllTeamLogos, getSeason } from '@/lib/serverUtils';
 import Link from 'next/link';
 import Image from 'next/image';
 
 export default async function ShortLeagueTable() {
-  const standings = await getLastSeason();
+  const standings = await getSeason();
   const teamLogos: Record<
     string,
     {

--- a/src/app/league-table/page.tsx
+++ b/src/app/league-table/page.tsx
@@ -1,9 +1,9 @@
 import { LeagueTableEntry } from '@/lib/types';
-import { getAllTeamLogos, getLastSeason } from '@/lib/serverUtils';
+import { getAllTeamLogos, getSeason } from '@/lib/serverUtils';
 import Image from 'next/image';
 
 export default async function LeagueTablePage() {
-  const standings = await getLastSeason();
+  const season = await getSeason();
   const teamLogos: Record<
     string,
     {
@@ -11,8 +11,9 @@ export default async function LeagueTablePage() {
       isTheTeamWeSupport: boolean;
     }
   > = await getAllTeamLogos();
-  const leagueTable = standings?.fields
+  const leagueTable = season?.fields
     .leagueTable as unknown as LeagueTableEntry[];
+  const seasonTitle = season.fields.title as unknown as string;
 
   return (
     <main className="bg-slate-50 min-h-screen text-slate-900">
@@ -20,7 +21,7 @@ export default async function LeagueTablePage() {
       <section className="bg-gradient-to-r from-red-600 to-red-700 text-white pt-24 md:pt-28 pb-12 md:pb-16">
         <div className="max-w-6xl mx-auto px-4 md:px-8">
           <h1 className="text-4xl md:text-5xl font-bold">League Table</h1>
-          <p className="text-white/80 mt-2">Season 2024/2025</p>
+          <p className="text-white/80 mt-2">{seasonTitle}</p>
         </div>
       </section>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,6 +91,7 @@ export type MatchEventFields = {
   teamHome: Entry<TeamSkeleton>;
   teamAway: Entry<TeamSkeleton>;
   heroBanner: Asset;
+  season?: Entry<SeasonSkeleton>;
 };
 
 export type LeagueTableEntry = {
@@ -110,6 +111,8 @@ export type LeagueTableEntry = {
 export type SeasonFields = {
   title: string;
   slug: string;
+  startYear: number;
+  isActive: boolean;
   leagueTable: LeagueTableEntry[];
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
## Summary

- Implements issue #27 - Filter everything by season
- Adds `isActive` field to Season content type for determining the current active season
- Creates new season-aware data fetching functions that default to the active season
- Updates all pages and components to use the new season filtering

### Key Changes

**New Data Fetching Functions:**
- `getActiveSeason()` - Gets the season where `isActive === true` with validation
- `getSeason(seasonSlug?)` - Gets a specific season by slug, or defaults to active season
- `getFixtures(seasonSlug?)` - Gets upcoming matches for a season
- `getResults(seasonSlug?)` - Gets past matches for a season
- `getMatches(seasonSlug?)` - Gets all matches for a season
- `getNextMatch(seasonSlug?)` - Gets the next upcoming match
- `getLatestResult(seasonSlug?)` - Gets the most recent completed match

**Validation:**
- Throws `ActiveSeasonError` if no active season exists
- Throws `ActiveSeasonError` if multiple seasons are marked as active

**Updated Pages/Components:**
- Fixtures page
- Results page
- League table page
- ShortLeagueTable component
- NextMatchBlock component
- LatestResultBlock component

## Contentful Setup Required

Before using this feature, you need to:
1. Add an `isActive` (Boolean) field to the Season content type in Contentful
2. Mark exactly one season as active (`isActive: true`)

## Test plan

- [ ] Verify `isActive` field exists on Season content type in Contentful
- [ ] Mark the current season as active
- [ ] Verify fixtures page shows only matches from the active season
- [ ] Verify results page shows only matches from the active season
- [ ] Verify league table shows data from the active season
- [ ] Verify homepage components (NextMatchBlock, LatestResultBlock, ShortLeagueTable) use active season
- [ ] Test error handling when no active season exists
- [ ] Test error handling when multiple seasons are marked active

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)