### PR TITLE
feat: add default hero banner image fallback

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,7 @@ export type TeamFields = {
   slug: string;
   logo: Asset;
   stadiumPhoto?: Asset;
+  heroImage?: Asset;
   foundationYear?: number;
   city?: string;
   stadium?: string;
@@ -135,3 +136,9 @@ export type Player = {
   bio: string;
   photoUrl: string;
 };
+
+export type DefaultSettingsFields = {
+  matchHeroBanner?: Asset;
+};
+
+export type DefaultSettingsSkeleton = EntrySkeletonType<DefaultSettingsFields>;


### PR DESCRIPTION
## Summary

Implements issue #29 - Default hero banner image with a fallback chain for hero banner images.

### Hero Banner Fallback Logic

1. **Match hero banner** - If the match has a `heroBanner` field set, use it
2. **Home team hero image** - If the home team has a `heroImage` field set, use it
3. **Default hero banner** - Use the `matchHeroBanner` from the `defaultSettings` content type

### Changes

**Types (`src/lib/types.ts`):**
- Added `heroImage?: Asset` field to `TeamFields`
- Added `DefaultSettingsFields` type with `matchHeroBanner` field
- Added `DefaultSettingsSkeleton` type

**Server Utils (`src/lib/serverUtils.tsx`):**
- Added `getDefaultSettings()` function to fetch the default settings entry
- Added `getDefaultHeroBannerUrl()` helper to get the default hero banner URL
- Updated `getMatchViewModel()` to use the fallback chain for hero banner

## Contentful Setup Required

1. Add a `heroImage` (Media) field to the **Team** content type
2. Create a new **defaultSettings** content type with:
   - `matchHeroBanner` (Media) field
3. Create a single `defaultSettings` entry and set the default hero banner image

## Test plan

- [ ] Verify match with heroBanner set displays the match hero banner
- [ ] Verify match without heroBanner but with home team heroImage displays the team hero image
- [ ] Verify match without either displays the default hero banner from defaultSettings
- [ ] Verify NextMatchBlock uses the correct hero banner
- [ ] Verify match detail page uses the correct hero banner

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)