### PR TITLE
Add season selection to League Table page

### DIFF
--- a/src/app/components/SeasonSelector.tsx
+++ b/src/app/components/SeasonSelector.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Entry } from 'contentful';
+import { SeasonSkeleton } from '@/lib/types';
+
+interface SeasonSelectorProps {
+  seasons: Entry<SeasonSkeleton>[];
+  currentSeasonSlug?: string;
+}
+
+export default function SeasonSelector({
+  seasons,
+  currentSeasonSlug,
+}: SeasonSelectorProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selectedSlug = searchParams?.get('season') || currentSeasonSlug || '';
+
+  const handleSeasonChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newSlug = e.target.value;
+
+    if (newSlug) {
+      router.push(`/league-table?season=${newSlug}`);
+    } else {
+      router.push('/league-table');
+    }
+  };
+
+  return (
+    <div className="relative inline-block">
+      <select
+        value={selectedSlug}
+        onChange={handleSeasonChange}
+        className="appearance-none bg-white border-2 border-red-600 text-slate-900 rounded-lg px-4 py-2 pr-10 font-semibold cursor-pointer hover:border-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-all duration-200 shadow-sm hover:shadow-md"
+        aria-label="Select season"
+      >
+        {seasons.map((season) => {
+          const title = season.fields.title as unknown as string;
+          const slug = season.fields.slug as unknown as string;
+          const isActive = season.fields.isActive as unknown as boolean;
+
+          return (
+            <option key={season.sys.id} value={slug}>
+              {title} {isActive ? '(Current)' : ''}
+            </option>
+          );
+        })}
+      </select>
+
+      {/* Custom dropdown arrow */}
+      <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-red-600">
+        <svg
+          className="fill-current h-4 w-4"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+        >
+          <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/app/league-table/error.tsx
+++ b/src/app/league-table/error.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function LeagueTableError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error('League Table Error:', error);
+  }, [error]);
+
+  return (
+    <main className="bg-slate-50 min-h-screen text-slate-900">
+      {/* Page Header */}
+      <section className="bg-gradient-to-r from-red-600 to-red-700 text-white pt-24 md:pt-28 pb-12 md:pb-16">
+        <div className="max-w-6xl mx-auto px-4 md:px-8">
+          <h1 className="text-4xl md:text-5xl font-bold">League Table</h1>
+          <p className="text-white/80 mt-2">Error Loading Data</p>
+        </div>
+      </section>
+
+      {/* Error Message */}
+      <section className="py-12 md:py-16 px-4 max-w-6xl mx-auto">
+        <div className="bg-white rounded-2xl shadow-card overflow-hidden p-8 md:p-12 text-center">
+          <div className="max-w-md mx-auto">
+            <svg
+              className="mx-auto h-16 w-16 text-red-600 mb-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+
+            <h2 className="text-2xl font-bold text-slate-900 mb-4">
+              Unable to Load League Table
+            </h2>
+
+            <p className="text-slate-600 mb-8">
+              {error.message ||
+                'An unexpected error occurred while loading the league table data. Please try again.'}
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <button
+                onClick={reset}
+                className="inline-flex items-center justify-center bg-gradient-to-r from-red-600 to-red-700 text-white px-6 py-3 rounded-full font-semibold hover:shadow-glow-red transition-all duration-300 hover:scale-105"
+              >
+                Try Again
+              </button>
+
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center bg-slate-200 text-slate-900 px-6 py-3 rounded-full font-semibold hover:bg-slate-300 transition-all duration-300"
+              >
+                Go Home
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/league-table/loading.tsx
+++ b/src/app/league-table/loading.tsx
@@ -1,0 +1,106 @@
+export default function LeagueTableLoading() {
+  return (
+    <main className="bg-slate-50 min-h-screen text-slate-900">
+      {/* Page Header Skeleton */}
+      <section className="bg-gradient-to-r from-red-600 to-red-700 text-white pt-24 md:pt-28 pb-12 md:pb-16">
+        <div className="max-w-6xl mx-auto px-4 md:px-8">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <div className="h-12 w-64 bg-white/20 rounded-lg animate-pulse" />
+              <div className="h-6 w-40 bg-white/20 rounded-lg animate-pulse mt-2" />
+            </div>
+            <div className="h-10 w-48 bg-white/20 rounded-lg animate-pulse" />
+          </div>
+        </div>
+      </section>
+
+      {/* League Table Skeleton */}
+      <section className="py-12 md:py-16 px-4 max-w-6xl mx-auto">
+        <div className="bg-white rounded-2xl shadow-card overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full table-auto text-sm md:text-base">
+              <thead className="bg-gradient-to-r from-red-600 to-red-700 text-white">
+                <tr>
+                  <th className="px-4 py-4 text-left font-semibold">#</th>
+                  <th className="px-4 py-4 text-left font-semibold">Team</th>
+                  <th className="px-4 py-4 text-center font-semibold">P</th>
+                  <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
+                    W
+                  </th>
+                  <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
+                    D
+                  </th>
+                  <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
+                    L
+                  </th>
+                  <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
+                    GF
+                  </th>
+                  <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
+                    GA
+                  </th>
+                  <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
+                    GD
+                  </th>
+                  <th className="px-4 py-4 text-center font-semibold">PTS</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({ length: 20 }).map((_, index) => (
+                  <tr
+                    key={index}
+                    className="border-b border-slate-100 border-l-4 border-l-transparent"
+                  >
+                    <td className="px-4 py-4">
+                      <div className="h-5 w-6 bg-slate-200 rounded animate-pulse" />
+                    </td>
+                    <td className="px-4 py-4">
+                      <div className="flex items-center space-x-3">
+                        <div className="w-8 h-8 bg-slate-200 rounded animate-pulse" />
+                        <div className="h-5 w-32 bg-slate-200 rounded animate-pulse" />
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-center">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                    <td className="px-4 py-4 text-center hidden sm:table-cell">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                    <td className="px-4 py-4 text-center hidden sm:table-cell">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                    <td className="px-4 py-4 text-center hidden sm:table-cell">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                    <td className="px-4 py-4 text-center hidden md:table-cell">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                    <td className="px-4 py-4 text-center hidden md:table-cell">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                    <td className="px-4 py-4 text-center hidden md:table-cell">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                    <td className="px-4 py-4 text-center">
+                      <div className="h-5 w-8 bg-slate-200 rounded animate-pulse mx-auto" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Legend Skeleton */}
+        <div className="mt-6 flex flex-wrap gap-6">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-slate-200 rounded animate-pulse" />
+              <div className="h-4 w-32 bg-slate-200 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/league-table/page.tsx
+++ b/src/app/league-table/page.tsx
@@ -1,143 +1,200 @@
 import { LeagueTableEntry } from '@/lib/types';
-import { getAllTeamLogos, getSeason } from '@/lib/serverUtils';
+import { getAllTeamLogos, getSeason, getAllSeasons, getActiveSeason } from '@/lib/serverUtils';
 import Image from 'next/image';
+import SeasonSelector from '@/app/components/SeasonSelector';
 
-export default async function LeagueTablePage() {
-  const season = await getSeason();
-  const teamLogos: Record<
-    string,
-    {
-      logoUrl: string;
-      isTheTeamWeSupport: boolean;
+interface LeagueTablePageProps {
+  searchParams: Promise<{ season?: string }>;
+}
+
+export default async function LeagueTablePage({
+  searchParams,
+}: LeagueTablePageProps) {
+  const params = await searchParams;
+  const seasonSlug = params.season;
+
+  // Fetch season data and all seasons for the selector
+  let season;
+  let error: string | null = null;
+
+  try {
+    season = await getSeason(seasonSlug);
+  } catch (e) {
+    error = e instanceof Error ? e.message : 'Failed to load season data';
+    // Fall back to active season if specified season not found
+    try {
+      season = await getActiveSeason();
+    } catch {
+      throw new Error('Unable to load season data');
     }
-  > = await getAllTeamLogos();
+  }
+
+  const [teamLogos, allSeasons] = await Promise.all([
+    getAllTeamLogos(),
+    getAllSeasons(),
+  ]);
+
   const leagueTable = season?.fields
     .leagueTable as unknown as LeagueTableEntry[];
   const seasonTitle = season.fields.title as unknown as string;
+  const isActiveSeason = season.fields.isActive as unknown as boolean;
+  const activeSeasonSlug = season.fields.slug as unknown as string;
+
+  // Determine display title based on season type
+  const displayTitle = isActiveSeason
+    ? 'League Table'
+    : `Final Standings - ${seasonTitle}`;
 
   return (
     <main className="bg-slate-50 min-h-screen text-slate-900">
       {/* Page Header */}
       <section className="bg-gradient-to-r from-red-600 to-red-700 text-white pt-24 md:pt-28 pb-12 md:pb-16">
         <div className="max-w-6xl mx-auto px-4 md:px-8">
-          <h1 className="text-4xl md:text-5xl font-bold">League Table</h1>
-          <p className="text-white/80 mt-2">{seasonTitle}</p>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <h1 className="text-4xl md:text-5xl font-bold">{displayTitle}</h1>
+              {!isActiveSeason && (
+                <p className="text-white/80 mt-2">{seasonTitle}</p>
+              )}
+            </div>
+            <SeasonSelector
+              seasons={allSeasons}
+              currentSeasonSlug={activeSeasonSlug}
+            />
+          </div>
+
+          {/* Error message if invalid season was requested */}
+          {error && seasonSlug && (
+            <div className="mt-4 bg-red-500/20 border border-red-400/50 rounded-lg px-4 py-3 text-white/90">
+              <p className="text-sm">
+                Season not found. Showing active season instead.
+              </p>
+            </div>
+          )}
         </div>
       </section>
 
       {/* League Table */}
       <section className="py-12 md:py-16 px-4 max-w-6xl mx-auto">
-        <div className="bg-white rounded-2xl shadow-card overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full table-auto text-sm md:text-base">
-              <thead className="bg-gradient-to-r from-red-600 to-red-700 text-white">
-                <tr>
-                  <th className="px-4 py-4 text-left font-semibold">#</th>
-                  <th className="px-4 py-4 text-left font-semibold">Team</th>
-                  <th className="px-4 py-4 text-center font-semibold">P</th>
-                  <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
-                    W
-                  </th>
-                  <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
-                    D
-                  </th>
-                  <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
-                    L
-                  </th>
-                  <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
-                    GF
-                  </th>
-                  <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
-                    GA
-                  </th>
-                  <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
-                    GD
-                  </th>
-                  <th className="px-4 py-4 text-center font-semibold">PTS</th>
-                </tr>
-              </thead>
-              <tbody>
-                {leagueTable.map((team, index) => {
-                  const isTop4 = index < 4;
-                  const isBottom3 = index >= leagueTable.length - 3;
-                  const isSupportedTeam =
-                    teamLogos[team.slug]?.isTheTeamWeSupport;
-
-                  return (
-                    <tr
-                      key={team.slug}
-                      className={`
-                        border-b border-slate-100 transition-colors duration-200
-                        ${
-                          isSupportedTeam
-                            ? 'bg-red-50 border-l-4 border-l-red-600'
-                            : 'border-l-4 border-l-transparent'
-                        }
-                        ${!isSupportedTeam && isTop4 ? 'bg-blue-50/50' : ''}
-                        ${!isSupportedTeam && isBottom3 ? 'bg-orange-50/50' : ''}
-                        ${
-                          !isSupportedTeam && !isTop4 && !isBottom3
-                            ? 'hover:bg-slate-50'
-                            : ''
-                        }
-                      `}
-                    >
-                      <td className="px-4 py-4 text-slate-600 font-medium">
-                        {team.position}
-                      </td>
-                      <td className="px-4 py-4">
-                        <div className="flex items-center space-x-3">
-                          <Image
-                            src={
-                              teamLogos[team.slug]?.logoUrl || '/placeholder.png'
-                            }
-                            alt={team.team}
-                            width={32}
-                            height={32}
-                            className="w-8 h-8 object-contain"
-                          />
-                          <span
-                            className={`${isSupportedTeam ? 'font-bold text-red-700' : 'font-medium text-slate-900'}`}
-                          >
-                            {team.team}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-4 py-4 text-center text-slate-600">
-                        {team.played}
-                      </td>
-                      <td className="px-4 py-4 text-center text-slate-600 hidden sm:table-cell">
-                        {team.wins}
-                      </td>
-                      <td className="px-4 py-4 text-center text-slate-600 hidden sm:table-cell">
-                        {team.draws}
-                      </td>
-                      <td className="px-4 py-4 text-center text-slate-600 hidden sm:table-cell">
-                        {team.losses}
-                      </td>
-                      <td className="px-4 py-4 text-center text-slate-600 hidden md:table-cell">
-                        {team.goalsFor}
-                      </td>
-                      <td className="px-4 py-4 text-center text-slate-600 hidden md:table-cell">
-                        {team.goalsAgainst}
-                      </td>
-                      <td className="px-4 py-4 text-center text-slate-600 hidden md:table-cell">
-                        {team.goalDifference > 0
-                          ? `+${team.goalDifference}`
-                          : team.goalDifference}
-                      </td>
-                      <td
-                        className={`px-4 py-4 text-center font-bold ${isSupportedTeam ? 'text-red-700' : 'text-slate-900'}`}
-                      >
-                        {team.points}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+        {!leagueTable || leagueTable.length === 0 ? (
+          <div className="bg-white rounded-2xl shadow-card overflow-hidden p-12 text-center">
+            <p className="text-slate-600 text-lg">
+              No league table data available for this season.
+            </p>
           </div>
-        </div>
+        ) : (
+          <div className="bg-white rounded-2xl shadow-card overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full table-auto text-sm md:text-base">
+                <thead className="bg-gradient-to-r from-red-600 to-red-700 text-white">
+                  <tr>
+                    <th className="px-4 py-4 text-left font-semibold">#</th>
+                    <th className="px-4 py-4 text-left font-semibold">Team</th>
+                    <th className="px-4 py-4 text-center font-semibold">P</th>
+                    <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
+                      W
+                    </th>
+                    <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
+                      D
+                    </th>
+                    <th className="px-4 py-4 text-center font-semibold hidden sm:table-cell">
+                      L
+                    </th>
+                    <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
+                      GF
+                    </th>
+                    <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
+                      GA
+                    </th>
+                    <th className="px-4 py-4 text-center font-semibold hidden md:table-cell">
+                      GD
+                    </th>
+                    <th className="px-4 py-4 text-center font-semibold">PTS</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {leagueTable.map((team, index) => {
+                    const isTop4 = index < 4;
+                    const isBottom3 = index >= leagueTable.length - 3;
+                    const isSupportedTeam =
+                      teamLogos[team.slug]?.isTheTeamWeSupport;
+
+                    return (
+                      <tr
+                        key={team.slug}
+                        className={`
+                          border-b border-slate-100 transition-colors duration-200
+                          ${
+                            isSupportedTeam
+                              ? 'bg-red-50 border-l-4 border-l-red-600'
+                              : 'border-l-4 border-l-transparent'
+                          }
+                          ${!isSupportedTeam && isTop4 ? 'bg-blue-50/50' : ''}
+                          ${!isSupportedTeam && isBottom3 ? 'bg-orange-50/50' : ''}
+                          ${
+                            !isSupportedTeam && !isTop4 && !isBottom3
+                              ? 'hover:bg-slate-50'
+                              : ''
+                          }
+                        `}
+                      >
+                        <td className="px-4 py-4 text-slate-600 font-medium">
+                          {team.position}
+                        </td>
+                        <td className="px-4 py-4">
+                          <div className="flex items-center space-x-3">
+                            <Image
+                              src={
+                                teamLogos[team.slug]?.logoUrl || '/placeholder.png'
+                              }
+                              alt={team.team}
+                              width={32}
+                              height={32}
+                              className="w-8 h-8 object-contain"
+                            />
+                            <span
+                              className={`${isSupportedTeam ? 'font-bold text-red-700' : 'font-medium text-slate-900'}`}
+                            >
+                              {team.team}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 text-center text-slate-600">
+                          {team.played}
+                        </td>
+                        <td className="px-4 py-4 text-center text-slate-600 hidden sm:table-cell">
+                          {team.wins}
+                        </td>
+                        <td className="px-4 py-4 text-center text-slate-600 hidden sm:table-cell">
+                          {team.draws}
+                        </td>
+                        <td className="px-4 py-4 text-center text-slate-600 hidden sm:table-cell">
+                          {team.losses}
+                        </td>
+                        <td className="px-4 py-4 text-center text-slate-600 hidden md:table-cell">
+                          {team.goalsFor}
+                        </td>
+                        <td className="px-4 py-4 text-center text-slate-600 hidden md:table-cell">
+                          {team.goalsAgainst}
+                        </td>
+                        <td className="px-4 py-4 text-center text-slate-600 hidden md:table-cell">
+                          {team.goalDifference > 0
+                            ? `+${team.goalDifference}`
+                            : team.goalDifference}
+                        </td>
+                        <td
+                          className={`px-4 py-4 text-center font-bold ${isSupportedTeam ? 'text-red-700' : 'text-slate-900'}`}
+                        >
+                          {team.points}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
 
         {/* Legend */}
         <div className="mt-6 flex flex-wrap gap-6 text-sm text-slate-600">

--- a/src/lib/serverUtils.tsx
+++ b/src/lib/serverUtils.tsx
@@ -81,6 +81,21 @@ export async function getSeason(
 }
 
 /**
+ * Gets all seasons ordered by startYear descending (newest first).
+ * Used for season selection dropdown in league table page.
+ */
+export async function getAllSeasons(): Promise<Entry<SeasonSkeleton>[]> {
+  const query: ContentfulQuery = {
+    content_type: 'season',
+    order: '-fields.startYear',
+    limit: 1000,
+  };
+  const entries = await contentfulClient.getEntries<SeasonSkeleton>(query);
+
+  return entries.items;
+}
+
+/**
  * @deprecated Use getSeason() instead. This function uses startYear ordering which should not be used.
  */
 export async function getLastSeason(): Promise<Entry<SeasonSkeleton>> {


### PR DESCRIPTION
## Summary
- Add season selector dropdown to the League Table page allowing users to view historical seasons
- URL-based selection: `/league-table?season={season-slug}` for bookmarking/sharing
- Default behavior shows active season when no URL parameter provided
- ShortLeagueTable component remains unaffected (always shows active season)

## Changes
- **serverUtils.tsx**: Added `getAllSeasons()` function to fetch all seasons from Contentful
- **SeasonSelector.tsx**: New client component with dropdown for season navigation
- **league-table/page.tsx**: Updated to read season from URL search params
- **league-table/loading.tsx**: New loading skeleton for better UX
- **league-table/error.tsx**: New error boundary for graceful error handling

## Features
- Season dropdown shows all seasons (newest first) with "(Current)" indicator on active season
- Historical seasons show "Final Standings - [Season Title]" header
- Invalid season slugs handled gracefully with error message
- Empty league table data shows fallback message
- Mobile responsive design

## Test plan
- [ ] Navigate to `/league-table` - should show active season by default
- [ ] Select a different season from dropdown - URL should update and data should change
- [ ] Direct URL access `/league-table?season=2023-24` - should show correct season
- [ ] Test invalid season `/league-table?season=invalid` - should show error
- [ ] Verify ShortLeagueTable on homepage still shows active season only
- [ ] Test mobile responsiveness of dropdown

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)