### PR TITLE
fix: prevent header from overlapping article title

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -30,7 +30,7 @@ export default async function ArticlePage(props: {
     .map((ref) => includes.find((entry) => entry.sys.id === ref.sys.id))
     .filter(Boolean) as ComponentEntry[];
   return (
-    <main className="max-w-3xl mx-auto px-4 py-12">
+    <main className="max-w-3xl mx-auto px-4 pt-24 md:pt-28 pb-12">
       <h1 className="text-4xl font-bold text-red-700 mb-4">{title}</h1>
       <p className="text-sm text-gray-500 mb-6">
         {new Date(publishDate).toLocaleDateString()}


### PR DESCRIPTION
Fixes #45

The article detail page had insufficient top padding (py-12 = 48px), causing the fixed header to overlap and crop the article title.

Changes:
- Update top padding from py-12 to pt-24 md:pt-28 (96px/112px)
- Maintain bottom padding of pb-12 (48px)
- Matches padding pattern used across all other pages
- Ensures proper clearance for the fixed header on all screen sizes

File changed:
- src/app/articles/[slug]/page.tsx

The article title is now fully visible and properly positioned below the fixed navigation header on both mobile and desktop viewports.