### PR TITLE
feat: Read match data from Stats JSON field (#62)

### DIFF
--- a/src/app/matches/[slug]/page.tsx
+++ b/src/app/matches/[slug]/page.tsx
@@ -56,7 +56,7 @@ export default async function MatchPage(props: {
           </p>
 
           {/* Competition and Season Logo */}
-          <div className="flex items-center justify-center gap-2 mb-6">
+          <div className="flex items-center justify-center gap-2 mb-2">
             {matchStatus !== 'pre-match' && matchViewModel.season?.logoUrl && (
               <Image
                 src={matchViewModel.season.logoUrl}
@@ -70,6 +70,23 @@ export default async function MatchPage(props: {
               {matchViewModel.competition} · {matchViewModel.location}
             </p>
           </div>
+
+          {/* Attendance and Referee */}
+          {matchStatus === 'post-match' && (matchViewModel.attendance || matchViewModel.referee) && (
+            <div className="flex items-center justify-center gap-4 mb-6 text-white/50 text-xs">
+              {matchViewModel.attendance && (
+                <span>Attendance: {matchViewModel.attendance.toLocaleString()}</span>
+              )}
+              {matchViewModel.attendance && matchViewModel.referee && (
+                <span>·</span>
+              )}
+              {matchViewModel.referee && (
+                <span>Referee: {matchViewModel.referee}</span>
+              )}
+            </div>
+          )}
+
+          {matchStatus !== 'post-match' && <div className="mb-4" />}
 
           {/* Teams */}
           <div className="flex justify-center items-center gap-6 md:gap-10">

--- a/src/lib/serverUtils.tsx
+++ b/src/lib/serverUtils.tsx
@@ -401,6 +401,8 @@ export async function getMatchViewModel(
     awayScore,
     homeScorers,
     awayScorers,
+    attendance: statsData?.match?.attendance,
+    referee: statsData?.match?.referee,
     season: seasonData,
     teamHome: {
       name: homeTeamDisplayName,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -162,6 +162,8 @@ export type StatsJson = {
       name?: string;
       city?: string;
     };
+    attendance?: number;
+    referee?: string;
   };
   goals?: StatsGoal[];
   cards?: StatsCard[];

--- a/src/lib/viewModels.tsx
+++ b/src/lib/viewModels.tsx
@@ -14,6 +14,8 @@ export type MatchViewModel = {
   awayScore?: number;
   homeScorers?: string | string[];
   awayScorers?: string | string[];
+  attendance?: number;
+  referee?: string;
   season?: {
     title: string;
     logoUrl?: string;


### PR DESCRIPTION
## Summary
- Add TypeScript types for the Stats JSON schema from Contentful
- Update `getMatchViewModel` to read match data from the Stats JSON field
- Falls back to existing fields (homeScore, awayScore, homeScorers, awayScorers, competition, venue) when Stats is not available
- Extracts scorers from goals array with minute information (e.g., "Bellingham 38'")

## Changes
- **types.ts**: Added `StatsJson`, `StatsGoal`, `StatsCard`, `StatsSubstitution`, `TeamStatistics`, `LineupPlayer` types
- **serverUtils.tsx**: Updated `getMatchViewModel` to read from stats field with fallback logic

## Test plan
- [ ] Verify matches with Stats JSON field display score correctly
- [ ] Verify scorers are extracted from goals array with minutes
- [ ] Verify competition name is read from Stats JSON
- [ ] Verify venue is read from Stats JSON
- [ ] Verify fallback works for matches without Stats JSON field
- [ ] Build passes without TypeScript errors

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)